### PR TITLE
Add publicPath to webpack config

### DIFF
--- a/packages/web/webpack.config.js
+++ b/packages/web/webpack.config.js
@@ -29,7 +29,8 @@ module.exports = {
   },
   output: {
     path: path.resolve(__dirname, 'dist'),
-    filename: 'bundle.js'
+    filename: 'bundle.js',
+    publicPath: '/'
   },
   plugins: [
     new HtmlWebpackPlugin({


### PR DESCRIPTION
Adds `output.publicPath` property so that routes containing slash symbol ("/") use absolute path for assets.